### PR TITLE
Adding "validates" as proper syntax

### DIFF
--- a/Syntaxes/Ruby on Rails.plist
+++ b/Syntaxes/Ruby on Rails.plist
@@ -303,7 +303,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(after_create|after_destroy|after_save|after_update|after_validation|after_validation_on_create|after_validation_on_update|before_create|before_destroy|before_save|before_update|before_validation|before_validation_on_create|before_validation_on_update|composed_of|belongs_to|has_one|has_many|has_and_belongs_to_many|validate|validate_on_create|validates_numericality_of|validate_on_update|validates_acceptance_of|validates_associated|validates_confirmation_of|validates_each|validates_format_of|validates_inclusion_of|validates_exclusion_of|validates_length_of|validates_presence_of|validates_size_of|validates_uniqueness_of|attr_protected|attr_accessible|attr_readonly|accepts_nested_attributes_for|default_scope|scope)\b</string>
+			<string>\b(after_create|after_destroy|after_save|after_update|after_validation|after_validation_on_create|after_validation_on_update|before_create|before_destroy|before_save|before_update|before_validation|before_validation_on_create|before_validation_on_update|composed_of|belongs_to|has_one|has_many|has_and_belongs_to_many|validate|validates|validate_on_create|validates_numericality_of|validate_on_update|validates_acceptance_of|validates_associated|validates_confirmation_of|validates_each|validates_format_of|validates_inclusion_of|validates_exclusion_of|validates_length_of|validates_presence_of|validates_size_of|validates_uniqueness_of|attr_protected|attr_accessible|attr_readonly|accepts_nested_attributes_for|default_scope|scope)\b</string>
 			<key>name</key>
 			<string>support.function.activerecord.rails</string>
 		</dict>


### PR DESCRIPTION
A while back, Rails got "sexy validation" added (https://rails.lighthouseapp.com/projects/8994/tickets/3058-patch-sexy-validations). While I believe the validates_presence_of, validates_uniqueness_of, etc. methods are preferred, "validates :presence => true, :uniqueness => true" is valid as well. 

This adds proper syntax highlighting for "validates" (a minor annoyance).
