### PR TITLE
Enable ruby syntax highlighting in the Gemfile

### DIFF
--- a/Syntaxes/Ruby on Rails.plist
+++ b/Syntaxes/Ruby on Rails.plist
@@ -7,6 +7,7 @@
 		<string>rb</string>
 		<string>rxml</string>
 		<string>builder</string>
+                <string>Gemfile</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>(?x)^


### PR DESCRIPTION
Simple change to allow syntax highlighting in the Gemfile
