### PR TITLE
Fix migration snippets for Rails 3.1 so they can find def down as well as def self.down

### DIFF
--- a/Support/bin/insert_add_column_or_create_table.rb
+++ b/Support/bin/insert_add_column_or_create_table.rb
@@ -25,7 +25,7 @@ else
 end
 
 # Find 'self.down' method
-if self_down = buffer.find { /^(\s*)def\s+self\.down\b/ }
+if self_down = buffer.find { /^(\s*)def\s+(self\.|)down\b/ }
   indentation = self_down[1]
 
   # Find the matching create_table clause in the schema.rb file

--- a/Support/bin/intelligent_migration_snippet.rb
+++ b/Support/bin/intelligent_migration_snippet.rb
@@ -94,7 +94,7 @@ def insert_migration(snippet, text)
   # find the beginning of self.down and insert down code, this is hardly robust.
   # assuming self.down is after self.up in the class
   lines.each_with_index do |line, i|
-    if line =~ /^\s*def\s+self\.down\b/
+    if line =~ /^\s*def\s+(self\.|)down\b/
       lines[i, 1] = [lines[i], down_code]
       break
     end


### PR DESCRIPTION
I'm not sure if I've covered them all, but this has fixed mtab-> and mcol-> in migrations for me.
